### PR TITLE
use addRawHeader since setRawHeader overwrites the previous Set-Cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,5 +223,6 @@ docker-compose up -d
 vendor/bin/phpstan analyse
 
 # run tests
+export HTTPBIN_BASEURI=http://localhost:8080
 vendor/bin/phpunit --configuration phpunit.xml.dist
 ```

--- a/src/Plug.php
+++ b/src/Plug.php
@@ -532,7 +532,7 @@ class Plug {
                 return $length;
             } else {
                 try {
-                    $responseHeaders->setRawHeader($header);
+                    $responseHeaders->addRawHeader($header);
                 } catch(InvalidArgumentException $e) {
 
                     // TODO (modethirteen, 20180424): add a handler for invalid http headers

--- a/tests/Plug/CurlInvoke/multipleSetCookieHeaders_Test.php
+++ b/tests/Plug/CurlInvoke/multipleSetCookieHeaders_Test.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+/**
+ * HyperPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace modethirteen\Http\Tests\Plug\CurlInvoke;
+
+use modethirteen\Http\Tests\PlugTestCase;
+
+class multipleSetCookieHeaders_Test extends  PlugTestCase  {
+
+    /**
+     * @test
+     */
+    public function Can_handle_multiple_Set_Cookie_response_headers() {
+        // arrange
+        $plug = $this->newHttpBinPlug()->at('cookies', 'set')
+            ->withAutoRedirects(0)
+            ->with('foo', 'foo')
+            ->with('bar', 'bar');
+
+        // act
+        $result = $plug->get();
+
+        // assert
+        $this->assertEquals(302, $result->getStatus());
+        $this->assertEquals('foo=foo; Path=/', $result->getHeaders()->getSetCookieHeaderLine('foo'));
+        $this->assertEquals('bar=bar; Path=/', $result->getHeaders()->getSetCookieHeaderLine('bar'));
+    }
+}


### PR DESCRIPTION
There appears to be a bug in `Plug` when multiple `Set-Cookie` headers are sent in a response.  Calling `addRawHeader` overwrites the previous header and the previous header.  I *think* this code is correct but please let me know if anything is wrong.  All the tests still pass against the local httpbin container but let me know if I've done something wrong or there's a better fix.

On an unrelated note, what's the purpose of the special case for HTTP/1.1?

```
if((new StringEx($header))->startsWithInvariantCase('HTTP/1.1')) {
```

Should this also include `HTTP/2`?

Thanks @modethirteen!